### PR TITLE
fix: use generic auth host when school_name is provided

### DIFF
--- a/custom_components/procare_activities/api.py
+++ b/custom_components/procare_activities/api.py
@@ -49,7 +49,13 @@ class ProcareApi:
         self._school_name = school_name
 
         if school_name:
-            self._auth_host = f"https://online-auth.{school_name}.procareconnect.com"
+            # Some Procare instances (e.g. Primrose Schools) use the generic
+            # auth endpoint but school-specific API and web hosts. DNS lookups
+            # confirm that online-auth.<school>.procareconnect.com does not
+            # exist for these providers, while api-school.<school>. and
+            # schools.<school>. do. Using the generic auth host works for all
+            # known configurations.
+            self._auth_host = DEFAULT_AUTH_HOST
             self._api_host = f"https://api-school.{school_name}.procareconnect.com"
             self._web_host = f"https://schools.{school_name}.procareconnect.com"
         else:


### PR DESCRIPTION
## Problem

When a `school_name` is configured, the integration builds all three endpoint URLs using the school subdomain:

```
online-auth.<school>.procareconnect.com
api-school.<school>.procareconnect.com
schools.<school>.procareconnect.com
```

However, some Procare deployments only expose school-specific subdomains for the API and web hosts — **not** for auth. For example, Primrose Schools:

```
online-auth.primrose.procareconnect.com  → NXDOMAIN ✗
api-school.primrose.procareconnect.com   → resolves ✓
schools.primrose.procareconnect.com      → resolves ✓
```

The DNS failure on the auth endpoint causes an unhandled exception in `async_login`, which bubbles up through the config flow's `except Exception` block and surfaces as the generic **"unknown"** error — with no actionable message for the user. This is the root cause reported in #3.

## Fix

Use `DEFAULT_AUTH_HOST` (`online-auth.procareconnect.com`) for authentication regardless of `school_name`. The auth token returned is then used against the school-specific API host, which works correctly.

This is safe because:
- For providers that have a school-specific auth subdomain, the generic auth endpoint also accepts their credentials (it's the same Procare auth service)
- For providers that don't (like Primrose), this is the only endpoint that works

## Testing

Verified against a Primrose Schools account (`school_name: primrose`). Config flow now completes successfully and the activity sensor populates correctly.

Closes #3