### PR TITLE
feat: configurable update interval (closes #9)

### DIFF
--- a/custom_components/procare_activities/__init__.py
+++ b/custom_components/procare_activities/__init__.py
@@ -9,7 +9,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.exceptions import ConfigEntryAuthFailed
 
-from .const import DOMAIN, PLATFORMS, CONF_SCHOOL_NAME
+from .const import DOMAIN, PLATFORMS, CONF_SCHOOL_NAME, CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL
 from .api import ProcareApi, ProcareAuthError
 
 _LOGGER = logging.getLogger(__name__)
@@ -36,12 +36,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         except Exception as err:
             raise UpdateFailed(f"Error communicating with API: {err}")
 
+    update_interval_minutes = entry.data.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
     coordinator = DataUpdateCoordinator(
         hass,
         _LOGGER,
         name="procare_activities_sensor",
         update_method=async_update_data,
-        update_interval=timedelta(minutes=35),
+        update_interval=timedelta(minutes=update_interval_minutes),
     )
     
     # Fetch initial data so we have it when platforms are set up.

--- a/custom_components/procare_activities/config_flow.py
+++ b/custom_components/procare_activities/config_flow.py
@@ -7,7 +7,7 @@ from homeassistant import config_entries
 from homeassistant.core import callback
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 
-from .const import DOMAIN, CONF_SCHOOL_NAME
+from .const import DOMAIN, CONF_SCHOOL_NAME, CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL
 from .api import ProcareApi, ProcareAuthError, ProcareNoChildrenError
 
 _LOGGER = logging.getLogger(__name__)
@@ -58,6 +58,9 @@ class ProcareConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema({
                 vol.Required(CONF_USERNAME): str,
                 vol.Required(CONF_PASSWORD): str,
+                vol.Optional(CONF_UPDATE_INTERVAL, default=DEFAULT_UPDATE_INTERVAL): vol.All(
+                    vol.Coerce(int), vol.Range(min=5, max=120)
+                ),
                 vol.Optional(CONF_SCHOOL_NAME): str,
             }),
             errors=errors,
@@ -82,6 +85,8 @@ class ProcareConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             }
             if self._user_input.get(CONF_SCHOOL_NAME):
                 data[CONF_SCHOOL_NAME] = self._user_input[CONF_SCHOOL_NAME]
+            if CONF_UPDATE_INTERVAL in self._user_input:
+                data[CONF_UPDATE_INTERVAL] = self._user_input[CONF_UPDATE_INTERVAL]
 
             return self.async_create_entry(
                 title=f"{kid_name} Activities",

--- a/custom_components/procare_activities/config_flow.py
+++ b/custom_components/procare_activities/config_flow.py
@@ -58,10 +58,10 @@ class ProcareConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema({
                 vol.Required(CONF_USERNAME): str,
                 vol.Required(CONF_PASSWORD): str,
+                vol.Optional(CONF_SCHOOL_NAME): str,
                 vol.Optional(CONF_UPDATE_INTERVAL, default=DEFAULT_UPDATE_INTERVAL): vol.All(
                     vol.Coerce(int), vol.Range(min=5, max=120)
                 ),
-                vol.Optional(CONF_SCHOOL_NAME): str,
             }),
             errors=errors,
         )

--- a/custom_components/procare_activities/const.py
+++ b/custom_components/procare_activities/const.py
@@ -4,6 +4,8 @@ DOMAIN = "procare_activities"
 PLATFORMS = ["sensor"]
 
 CONF_SCHOOL_NAME = "school_name"
+CONF_UPDATE_INTERVAL = "update_interval"
+DEFAULT_UPDATE_INTERVAL = 15  # minutes
 
 DEFAULT_AUTH_HOST = "https://online-auth.procareconnect.com"
 DEFAULT_API_HOST = "https://api-school.procareconnect.com"

--- a/custom_components/procare_activities/const.py
+++ b/custom_components/procare_activities/const.py
@@ -5,7 +5,7 @@ PLATFORMS = ["sensor"]
 
 CONF_SCHOOL_NAME = "school_name"
 CONF_UPDATE_INTERVAL = "update_interval"
-DEFAULT_UPDATE_INTERVAL = 15  # minutes
+DEFAULT_UPDATE_INTERVAL = 35  # keep original default, minutes
 
 DEFAULT_AUTH_HOST = "https://online-auth.procareconnect.com"
 DEFAULT_API_HOST = "https://api-school.procareconnect.com"


### PR DESCRIPTION
## Summary

Adds an optional `update_interval` field (in minutes) to the setup config flow, making the polling frequency user-configurable.

- Default remains 35 minutes (no behavior change for existing installs)
- Valid range: 5–120 minutes (enforced via voluptuous)
- Closes #9

> ⚠️ As noted by the maintainer in #9: polling too frequently risks rate-limiting or account suspension. The 5-minute minimum is a soft guard, but users should use good judgement.