### PR TITLE
Fix bottle parsing and reformat nap title

### DIFF
--- a/custom_components/procare_activities/api.py
+++ b/custom_components/procare_activities/api.py
@@ -220,38 +220,36 @@ class ProcareApi:
                 elif activity_type == "nap" and data:
                     start_time_str = data.get('start_time')
                     end_time_str = data.get('end_time')
-                    if end_time_str:
+                    if end_time_str and start_time_str:
+                        start_dt = datetime.fromisoformat(start_time_str)
+                        end_dt = datetime.fromisoformat(end_time_str)
+                        total_minutes = int((end_dt - start_dt).total_seconds() // 60)
+                        hours, minutes = divmod(total_minutes, 60)
+                        if hours and minutes:
+                            duration = f"{hours}h {minutes}m"
+                        elif hours:
+                            duration = f"{hours}h"
+                        else:
+                            duration = f"{minutes}m"
+                        title = (
+                            f"Nap from {start_dt.strftime('%-I:%M %p')} "
+                            f"to {end_dt.strftime('%-I:%M %p')} ({duration})"
+                        )
+                    elif end_time_str:
                         end_dt = datetime.fromisoformat(end_time_str)
                         title = f"Nap Ended at {end_dt.strftime('%-I:%M %p')}"
-                        if start_time_str:
-                            start_dt = datetime.fromisoformat(start_time_str)
-                            total_minutes = int((end_dt - start_dt).total_seconds() // 60)
-                            hours, minutes = divmod(total_minutes, 60)
-                            if hours and minutes:
-                                duration = f"{hours}h {minutes}m"
-                            elif hours:
-                                duration = f"{hours}h"
-                            else:
-                                duration = f"{minutes}m"
-                            details = f"Started {start_dt.strftime('%-I:%M %p')} ({duration})"
                     elif start_time_str:
                         start_dt = datetime.fromisoformat(start_time_str)
                         title = f"Nap Started at {start_dt.strftime('%-I:%M %p')}"
                 elif activity_type == "bottle" and data:
-                    quantity = data.get('quantity')
-                    unit = (
-                        data.get('quantity_unit')
-                        or data.get('measurement')
-                        or data.get('unit')
-                        or "oz"
-                    )
-                    if quantity not in (None, ""):
-                        title = f"Bottle: {quantity} {unit}".strip()
+                    amount = data.get('amount')
+                    if amount not in (None, ""):
+                        title = f"Bottle: {amount} oz"
                     else:
                         title = "Bottle"
-                    food_type = data.get('food_type') or data.get('type')
-                    if food_type:
-                        details = food_type
+                    desc = data.get('desc')
+                    if desc:
+                        details = desc
                 elif activity_type == "bathroom" and data:
                     title = f"Diaper: {data.get('sub_type', 'check')}"
 

--- a/custom_components/procare_activities/api.py
+++ b/custom_components/procare_activities/api.py
@@ -217,9 +217,41 @@ class ProcareApi:
                 elif activity_type == "meal" and data:
                     title = f"Meal: {data.get('type', 'Meal')}"
                     details = f"{data.get('desc', '')} ({data.get('quantity', '')})".strip()
-                elif activity_type == "nap" and data and data.get('start_time'):
-                    start_time = datetime.fromisoformat(data['start_time']).strftime("%-I:%M %p")
-                    title = f"Nap Started at {start_time}"
+                elif activity_type == "nap" and data:
+                    start_time_str = data.get('start_time')
+                    end_time_str = data.get('end_time')
+                    if end_time_str:
+                        end_dt = datetime.fromisoformat(end_time_str)
+                        title = f"Nap Ended at {end_dt.strftime('%-I:%M %p')}"
+                        if start_time_str:
+                            start_dt = datetime.fromisoformat(start_time_str)
+                            total_minutes = int((end_dt - start_dt).total_seconds() // 60)
+                            hours, minutes = divmod(total_minutes, 60)
+                            if hours and minutes:
+                                duration = f"{hours}h {minutes}m"
+                            elif hours:
+                                duration = f"{hours}h"
+                            else:
+                                duration = f"{minutes}m"
+                            details = f"Started {start_dt.strftime('%-I:%M %p')} ({duration})"
+                    elif start_time_str:
+                        start_dt = datetime.fromisoformat(start_time_str)
+                        title = f"Nap Started at {start_dt.strftime('%-I:%M %p')}"
+                elif activity_type == "bottle" and data:
+                    quantity = data.get('quantity')
+                    unit = (
+                        data.get('quantity_unit')
+                        or data.get('measurement')
+                        or data.get('unit')
+                        or "oz"
+                    )
+                    if quantity not in (None, ""):
+                        title = f"Bottle: {quantity} {unit}".strip()
+                    else:
+                        title = "Bottle"
+                    food_type = data.get('food_type') or data.get('type')
+                    if food_type:
+                        details = food_type
                 elif activity_type == "bathroom" and data:
                     title = f"Diaper: {data.get('sub_type', 'check')}"
 


### PR DESCRIPTION
## Summary

- **Bottle:** the branch added in f433d2b looked up `quantity`, `food_type`, `quantity_unit`/`measurement`/`unit` — none of those exist in the live payload, so every bottle rendered as a bare `Bottle` with empty details. Real keys are `amount` and `desc`; there is no unit field (Procare's UI just renders oz). Now `{amount: "6", desc: "HA"}` → title `Bottle: 6 oz`, details `HA`.
- **Nap:** collapse the two-field "Nap Ended at … / Started … (Nm)" form into a single self-contained title: `Nap from 3:50 PM to 4:25 PM (34m)`. Details fall back to the activity comment like every other type. Original "Nap Ended at …" / "Nap Started at …" branches still cover the edge cases where only one timestamp is present.

Verified against live API responses pulled from an account in the Primrose realm — both `nap_activity` and `bottle_activity` records produce the expected output, including multi-hour naps (`1h 37m`).

## Test plan

- [ ] Reload integration; confirm latest bottle activity shows `Bottle: N oz` (state) and the desc abbreviation (attribute `details`).
- [ ] Confirm an ended nap shows `Nap from X to Y (Zm)` (state) instead of `Nap Started at X`.
- [ ] Confirm an in-progress nap (start_time only) still shows `Nap Started at X`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)